### PR TITLE
Allow users to toggle --only-binary flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     - run: uv --version
 
   setup_uv_lockfile:
-    name: setup-uv [lockfile-onlybinary-true]
+    name: setup-uv [only-binary=:all:]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -57,8 +57,8 @@ jobs:
     - run: uv --version
     - run: python -m build --version
 
-  setup_uv_lockfile_binaries:
-    name: setup-uv [lockfile-onlybinary-false]
+  setup_uv_lockfile_only_binary_none:
+    name: setup-uv [only-binary=:none:]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -70,8 +70,8 @@ jobs:
     - name: Set up Python environment
       uses: ./setup-uv
       with:
-        onlybinary: false
         lockfile: .github/workflows/lockfile.txt
+        only-binary: ":none:"
     - run: uv --version
     - run: python -m build --version
 
@@ -111,6 +111,7 @@ jobs:
     - setup_uv_default
     - setup_uv_version
     - setup_uv_lockfile
+    - setup_uv_lockfile_only_binary_none
     - setup_mdbook
     - setup_cargo_bundle_licenses
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     - run: uv --version
 
   setup_uv_lockfile:
-    name: setup-uv [lockfile]
+    name: setup-uv [lockfile-onlybinary-true]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -53,6 +53,24 @@ jobs:
     - name: Set up Python environment
       uses: ./setup-uv
       with:
+        lockfile: .github/workflows/lockfile.txt
+    - run: uv --version
+    - run: python -m build --version
+
+  setup_uv_lockfile_binaries:
+    name: setup-uv [lockfile-onlybinary-false]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - name: Set up Python
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: "3.12"
+    - name: Set up Python environment
+      uses: ./setup-uv
+      with:
+        onlybinary: false
         lockfile: .github/workflows/lockfile.txt
     - run: uv --version
     - run: python -m build --version

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -25,6 +25,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary && '--only-binary=:all:' || ''}}
+      ONLY_BINARY: ${{ inputs.onlybinary=='true' && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -26,6 +26,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary===true && '--only-binary=:all:' || ''}}
+      ONLY_BINARY: ${{ inputs.onlybinary==true && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -13,7 +13,7 @@ inputs:
   onlybinary:
     description: 'Allow building dependencies from source.'
     required: false
-    default: 'false'
+    default: 'true'
 
 runs:
   using: "composite"

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -25,6 +25,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ ${{ inputs.onlybinary }} && "--only-binary=:all:" || ""}}
+      ONLY_BINARY: ${{ inputs.onlybinary && "--only-binary=:all:" || ""}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'Packages to install.'
     required: false
     default: ''
+  onlybinary:
+    description: 'Allow building dependencies from source.'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -20,5 +24,7 @@ runs:
 
   - name: Install
     if: ${{ inputs.lockfile != '' }}
-    run: "uv pip sync ${{ inputs.lockfile }} --only-binary :all: --system --reinstall"
+    env:
+      ONLY_BINARY: ${{ {{ inputs.onlybinary }} && "--only-binary=:all:" || ""}}
+    run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -26,6 +26,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary==true && '--only-binary=:all:' || ''}}
+      ONLY_BINARY: ${{ inputs.onlybinary===true && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -13,7 +13,7 @@ inputs:
   onlybinary:
     description: 'Allow building dependencies from source.'
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: "composite"

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -25,6 +25,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary && "--only-binary=:all:" || ""}}
+      ONLY_BINARY: ${{ inputs.onlybinary && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -10,11 +10,10 @@ inputs:
     description: 'Packages to install.'
     required: false
     default: ''
-  onlybinary:
-    type: boolean
-    description: 'Allow building dependencies from source.'
+  only-binary:
+    description: 'Value to pass to the --only-binary option.'
     required: false
-    default: true
+    default: ':all:'
 
 runs:
   using: "composite"
@@ -25,7 +24,5 @@ runs:
 
   - name: Install
     if: ${{ inputs.lockfile != '' }}
-    env:
-      ONLY_BINARY: ${{ inputs.onlybinary==true && '--only-binary=:all:' || ''}}
-    run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
+    run: "uv pip sync ${{ inputs.lockfile }} --only-binary=${{ inputs.only-binary }} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -11,9 +11,10 @@ inputs:
     required: false
     default: ''
   onlybinary:
+    type: boolean
     description: 'Allow building dependencies from source.'
     required: false
-    default: 'true'
+    default: true
 
 runs:
   using: "composite"
@@ -25,6 +26,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary=='true' && '--only-binary=:all:' || ''}}
+      ONLY_BINARY: ${{ inputs.onlybinary && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -25,6 +25,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ {{ inputs.onlybinary }} && "--only-binary=:all:" || ""}}
+      ONLY_BINARY: ${{ ${{ inputs.onlybinary }} && "--only-binary=:all:" || ""}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -26,6 +26,6 @@ runs:
   - name: Install
     if: ${{ inputs.lockfile != '' }}
     env:
-      ONLY_BINARY: ${{ inputs.onlybinary && '--only-binary=:all:' || ''}}
+      ONLY_BINARY: ${{ inputs.onlybinary==true && '--only-binary=:all:' || ''}}
     run: "uv pip sync ${{ inputs.lockfile }} ${ONLY_BINARY} --system --reinstall"
     shell: bash


### PR DESCRIPTION
To resolve #8, the `--only-binary flag` has been made optional. While on by default (to ease in debugging), it can be disabled for packages with unresolvable dependencies.