### PR TITLE
Add support for uv `python-version` key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      with:
-        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
     - run: uv --version
@@ -32,13 +28,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      with:
-        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
       with:
         version: 0.4.0
+        python-version: "3.12"
     - run: uv --version
 
   setup_uv_lockfile:
@@ -47,14 +41,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      with:
-        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
       with:
         lockfile: .github/workflows/lockfile.txt
+        python-version: "3.12"
     - run: uv --version
     - run: python -m build --version
 
@@ -64,15 +55,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      with:
-        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
       with:
         lockfile: .github/workflows/lockfile.txt
         only-binary: ":none:"
+        python-version: "3.12"
     - run: uv --version
     - run: python -m build --version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,16 +54,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      with:
-        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
       with:
         lockfile: .github/workflows/lockfile.txt
         only-binary: ":none:"
-        # python-version: "3.12"
+        python-version: "3.12"
     - run: uv --version
     - run: python -m build --version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up Python
     - name: Set up Python environment
       uses: ./setup-uv
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,12 +54,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Python
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      with:
+        python-version: "3.12"
     - name: Set up Python environment
       uses: ./setup-uv
       with:
         lockfile: .github/workflows/lockfile.txt
         only-binary: ":none:"
-        python-version: "3.12"
+        # python-version: "3.12"
     - run: uv --version
     - run: python -m build --version
 

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -26,8 +26,12 @@ runs:
     uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
     with:
       version: ${{ inputs.version }}
-      python-version: ${{ inputs.python-version }}
       enable-cache: false
+
+  - name: Install python version
+    if: ${{ inputs.python-version != '' }}
+    run: uv python install ${{ inputs.python-version }}
+    shell: bash
 
   - name: Install packages
     if: ${{ inputs.lockfile != '' }}

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: 'uv version to install.'
     required: false
     default: '0.5.26'
+  python-version:
+    description: 'Python version to install.'
+    required: false
+    default: ''
   lockfile:
     description: 'Packages to install.'
     required: false
@@ -21,7 +25,8 @@ runs:
   - name: Setup uv
     uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
     with:
-      version: ${{ inputs.version }}  
+      version: ${{ inputs.version }}
+      python-version: ${{ inputs.python-version }}
 
   - name: Install packages
     if: ${{ inputs.lockfile != '' }}

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -9,7 +9,7 @@ inputs:
   python-version:
     description: 'Python version to install.'
     required: false
-    default: ''
+    default: '3.13'
   lockfile:
     description: 'Packages to install.'
     required: false

--- a/setup-uv/action.yaml
+++ b/setup-uv/action.yaml
@@ -27,6 +27,7 @@ runs:
     with:
       version: ${{ inputs.version }}
       python-version: ${{ inputs.python-version }}
+      enable-cache: false
 
   - name: Install packages
     if: ${{ inputs.lockfile != '' }}


### PR DESCRIPTION
After a huge amount of testing, it seems like not using `actions/setup-python` breaks uv on windows in a number of confusing ways. Until this is changed, I think it best to leave the workflow as it is.